### PR TITLE
Fix: Convert NumPy array to tuple in minmax_size resize operation

### DIFF
--- a/rapid_latex_ocr/utils.py
+++ b/rapid_latex_ocr/utils.py
@@ -75,7 +75,7 @@ class PreProcess:
             ratios = [a / b for a, b in zip(img.size, self.max_dims)]
             if any([r > 1 for r in ratios]):
                 size = np.array(img.size) // max(ratios)
-                img = img.resize(size.astype(int), Image.BILINEAR)
+                img = img.resize(tuple(size.astype(int)), Image.BILINEAR)
 
         if self.min_dims is not None:
             padded_size: List[Union[int, int]] = [


### PR DESCRIPTION
## Bug Report and Fix for rapid_latex_ocr

### Description of the Bug

When using the `rapid_latex_ocr` library, an error occurs during image resizing. The error message suggests that a NumPy array is being passed to PIL's `resize` method instead of the expected tuple.

### Error Message

```
ValueError: The truth value of an array with more than one element is ambiguous. Use a.any() or a.all()
```

### Steps to Reproduce

1. Install `rapid_latex_ocr`
2. Attempt to process a large size image using the `LatexOCR` class
3. The error occurs in the `minmax_size` function in `utils.py`

### Proposed Fix

In the file `rapid_latex_ocr/utils.py`, in the `minmax_size` function, change the line:

```python
img = img.resize(size.astype(int), Image.BILINEAR)
```

to:

```python
img = img.resize(tuple(size.astype(int)), Image.BILINEAR)
```

This change converts the NumPy array to a tuple, which is the expected input for PIL's `resize` method.

### Additional Notes

This fix has been tested on Python 3.11 and resolves the ValueError. It may be worth considering adding a type check or conversion for the `size` parameter to ensure it's always in the correct format for `resize`.