### PR TITLE
Fix "ValueError: height and width must be > 0" in minmax_size method

### DIFF
--- a/rapid_latex_ocr/utils.py
+++ b/rapid_latex_ocr/utils.py
@@ -75,6 +75,7 @@ class PreProcess:
             ratios = [a / b for a, b in zip(img.size, self.max_dims)]
             if any([r > 1 for r in ratios]):
                 size = np.array(img.size) // max(ratios)
+                size = np.maximum(size, 1)
                 img = img.resize(tuple(size.astype(int)), Image.BILINEAR)
 
         if self.min_dims is not None:


### PR DESCRIPTION
## Bug Report and Fix

### Description of the Bug
I have a pipeline to find where the formulas are located in a page, and pass their coordinates to rapid-latex-ocr to extract them in LaTeX format. And this process is failed in the following specific image that is found by my pipeline (even though there is no formula in it, it should not fail the process):

![formula_image_6_394](https://github.com/user-attachments/assets/574a70a2-3d29-4bc5-8a22-9dc5927013e6)


### Error Message
```
ValueError: height and width must be > 0
```

### Steps to Reproduce
1. Install rapid-latex-ocr
2. Download the image and try to process it with rapid-latex-ocr

- The error occurs in the minmax_size function in utils.py


### Proposed Fix

In the file `rapid_latex_ocr/utils.py`, in the `minmax_size` function, after this line:

```py
size = np.array(img.size) // max(ratios)
```

add this line to ensure the size is at least 1:

```py
size = np.maximum(size, 1)
```

### Additional Notes
This fix has been tested on Python 3.11 and resolves this error.